### PR TITLE
bazel: make cmake deps consumer-portable (hermetic_cxx_runtime flag)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 # Direct dependencies from BCR
 bazel_dep(name = "yaml-cpp", version = "0.9.0")

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -2,8 +2,27 @@
 
 exports_files(["export_deps.sh"])
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# When kepler-formal is the root module its hermetic clang toolchain compiles
+# the rules_foreign_cc cmake deps (naja/capnproto/onetbb), so those builds must
+# link the hermetic static libc++/libc++abi/libunwind archives. A downstream
+# consumer that builds kepler-formal's deps with its OWN toolchain must NOT get
+# those archives (mismatched, non-PIC static libc++abi cannot link into naja's
+# and TBB's shared libs). Consumers set this flag False.
+bool_flag(
+    name = "hermetic_cxx_runtime_enabled",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "hermetic_runtime",
+    constraint_values = ["@platforms//os:linux"],
+    flag_values = {":hermetic_cxx_runtime_enabled": "True"},
+    visibility = ["//visibility:public"],
+)
 
 # The hermetic-llvm toolchain passes libc++/libc++abi/libunwind to linker
 # actions as Bazel link inputs; its -L "library search directories" contain

--- a/bazel/capnproto.BUILD.bazel
+++ b/bazel/capnproto.BUILD.bazel
@@ -32,7 +32,7 @@ cmake(
         # See naja.BUILD.bazel: the hermetic toolchain's C++ runtime
         # archives are Bazel link inputs rules_foreign_cc doesn't capture,
         # and the -L'd search directories contain deliberate stubs.
-        "//conditions:default": CAPNPROTO_CMAKE_CACHE_ENTRIES | {
+        "@kepler-formal//bazel:hermetic_runtime": CAPNPROTO_CMAKE_CACHE_ENTRIES | {
             "CMAKE_CXX_STANDARD_LIBRARIES": " ".join([
                 "$${EXT_BUILD_DEPS}/lib/liblibcxx.static.a",
                 "$${EXT_BUILD_DEPS}/lib/liblibcxxabi.static.a",
@@ -40,11 +40,15 @@ cmake(
                 "-lm",
             ]),
         },
+        # Consumer toolchain (hermetic_cxx_runtime_enabled=False): use the
+        # consumer's own libc++; no hermetic archives.
+        "//conditions:default": CAPNPROTO_CMAKE_CACHE_ENTRIES,
     }),
     build_args = ["-j4"],
     deps = select({
         "@platforms//os:macos": [],
-        "//conditions:default": ["@kepler-formal//bazel:hermetic_cxx_runtime"],
+        "@kepler-formal//bazel:hermetic_runtime": ["@kepler-formal//bazel:hermetic_cxx_runtime"],
+        "//conditions:default": [],
     }),
     lib_source = ":all_srcs",
     out_binaries = [

--- a/bazel/naja.BUILD.bazel
+++ b/bazel/naja.BUILD.bazel
@@ -50,7 +50,9 @@ HERMETIC_LLVM_CXX_STANDARD_LIBRARIES = {
 
 HERMETIC_CXX_RUNTIME_DEPS = select({
     "@platforms//os:macos": [],
-    "//conditions:default": ["@kepler-formal//bazel:hermetic_cxx_runtime"],
+    "@kepler-formal//bazel:hermetic_runtime": ["@kepler-formal//bazel:hermetic_cxx_runtime"],
+    # Consumer toolchain (hermetic_cxx_runtime_enabled=False): its own libc++.
+    "//conditions:default": [],
 })
 
 NAJA_MACOS_CMAKE_CACHE_ENTRIES = dict(
@@ -111,8 +113,14 @@ cmake(
     build_args = ["-j2"],
     cache_entries = select({
         "@platforms//os:macos": NAJA_MACOS_CMAKE_CACHE_ENTRIES,
-        "//conditions:default": NAJA_CMAKE_CACHE_ENTRIES |
-                                HERMETIC_LLVM_CXX_STANDARD_LIBRARIES,
+        "@kepler-formal//bazel:hermetic_runtime": NAJA_CMAKE_CACHE_ENTRIES |
+                                                  HERMETIC_LLVM_CXX_STANDARD_LIBRARIES,
+        # Consumer toolchain (hermetic_cxx_runtime_enabled=False): use the
+        # consumer's own libc++; keep only the /usr/include fallback that lets
+        # naja find the host Python headers, drop the hermetic archives.
+        "//conditions:default": NAJA_CMAKE_CACHE_ENTRIES | {
+            "CMAKE_CXX_FLAGS": "-idirafter /usr/include",
+        },
     }),
     # Copy static libs that cmake builds but doesn't install
     # (naja_nl_dump has no install() command; naja_verilog's is guarded by PROJECT_IS_TOP_LEVEL)

--- a/bazel/naja_includes.bzl
+++ b/bazel/naja_includes.bzl
@@ -6,6 +6,10 @@ host-installed Naja under /usr/local/include can otherwise win the short
 """
 
 NAJA_HEADER_COPTS = [
+    # Kepler and Naja's headers require C++20. The root module sets this via
+    # .bazelrc (--cxxopt=-std=c++20), but that does not reach a downstream
+    # consumer, so set it on the targets themselves.
+    "-std=c++20",
     "-iquoteexternal/+deps+naja/src/src/dnl",
     "-iquoteexternal/+deps+naja/src/src/nl/netlist/core",
     "-iquoteexternal/+deps+naja/src/src/nl/netlist/snl",

--- a/bazel/onetbb.BUILD.bazel
+++ b/bazel/onetbb.BUILD.bazel
@@ -25,7 +25,7 @@ cmake(
         # tbbmalloc's linker version script assigns symbols that are only
         # defined when ITT is enabled; GNU ld ignores that, ld.lld (the
         # hermetic toolchain's linker) errors without --undefined-version.
-        "//conditions:default": ONETBB_CMAKE_CACHE_ENTRIES | {
+        "@kepler-formal//bazel:hermetic_runtime": ONETBB_CMAKE_CACHE_ENTRIES | {
             "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--undefined-version",
             # See naja.BUILD.bazel: link the hermetic C++ runtime into the
             # shared libraries so their libc++ symbols resolve at load time.
@@ -36,10 +36,17 @@ cmake(
                 "-lm",
             ]),
         },
+        # Consumer toolchain (hermetic_cxx_runtime_enabled=False): the consumer's
+        # own libc++ is used; do not inject the hermetic archives. Keep
+        # --undefined-version (ld.lld, incl. consumers using lld).
+        "//conditions:default": ONETBB_CMAKE_CACHE_ENTRIES | {
+            "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--undefined-version",
+        },
     }),
     deps = select({
         "@platforms//os:macos": [],
-        "//conditions:default": ["@kepler-formal//bazel:hermetic_cxx_runtime"],
+        "@kepler-formal//bazel:hermetic_runtime": ["@kepler-formal//bazel:hermetic_cxx_runtime"],
+        "//conditions:default": [],
     }),
     build_args = ["-j4"],
     lib_source = ":all_srcs",


### PR DESCRIPTION
## Problem

Building `//src/bin:kepler-formal` works when kepler-formal is the **root** module (its hermetic LLVM toolchain compiles everything). But a downstream project that consumes kepler-formal via `git_override`/`bazel_dep` and builds the cmake deps with **its own** toolchain (kepler's hermetic toolchain is a dev_dependency and doesn't hijack the consumer — see #149) hits three failures:

1. **Mismatched hermetic runtime.** The `naja`/`capnproto`/`onetbb` overlays unconditionally inject the hermetic static `libc++`/`libc++abi`/`libunwind` archives (`//bazel:hermetic_cxx_runtime`). Compiled by a *different* toolchain, that non-PIC static libc++abi cannot be linked into naja's and TBB's **shared** libraries:
   ```
   ld.lld: error: relocation R_X86_64_TPOFF32 against …eh_globals cannot be used with -shared
   ```
2. **C++ standard.** kepler's cc_libraries need C++20 but receive it only from the root `.bazelrc` (`--cxxopt=-std=c++20`), which does not reach a consumer, so the C++20 naja headers fail to compile.

## Fix

- Add a `//bazel:hermetic_cxx_runtime_enabled` bool_flag (**default True**) + a linux `config_setting`. Each overlay's Linux branch becomes 3-way: macos / hermetic (flag True) / **consumer** (flag False → no hermetic archives; the consumer's own libc++ is used). macOS is unaffected.
- Set `-std=c++20` on the shared `NAJA_HEADER_COPTS` so kepler's cc_libraries compile as C++20 regardless of the consumer's `.bazelrc`.

## Impact / testing

- **Root unchanged** (flag defaults True → hermetic branch): verified building `//src/bin:kepler-formal` and `@onetbb` at root.
- **Consumer** (`--@kepler-formal//bazel:hermetic_cxx_runtime_enabled=False --force_pic`): capnproto, onetbb, naja, and the final `//src/bin:kepler-formal` now build, and the binary runs (`--help` prints usage). Validated end-to-end from a downstream bazel project.

Advances the Phase 2 goal in `docs/bcr-roadmap.md` (consumable by downstreams like bazel-orfs). Consumers also need a `rules_foreign_cc` with bazel-contrib/rules_foreign_cc#1574 (`pwd -P`) when building under `--incompatible_strict_action_env`.