### PR TITLE
bazel: derive naja -iquote prefix from repo mapping

### DIFF
--- a/bazel/naja_includes.bzl
+++ b/bazel/naja_includes.bzl
@@ -3,32 +3,48 @@
 Bazel's transitive `includes` are emitted as system include paths.  On macOS a
 host-installed Naja under /usr/local/include can otherwise win the short
 `#include "DNL.h"` lookup before the fetched @naja headers are considered.
+
+The -iquote prefix is derived from @naja's repo mapping instead of a
+hardcoded canonical repo name: as the root module the repo materializes at
+external/+deps+naja, but in a downstream consumer it is
+external/<module>++deps+naja — a hardcoded path dangles there, quoted
+includes fall through to the transitive system paths, and headers resolve
+through two physical copies (source tree + cmake install), which #pragma
+once cannot deduplicate.
 """
+
+_NAJA_ROOT = Label("@naja//:BUILD").workspace_root
+
+_NAJA_QUOTE_INCLUDE_DIRS = [
+    "src/src/dnl",
+    "src/src/nl/netlist/core",
+    "src/src/nl/netlist/snl",
+    "src/src/core",
+    "src/src/bne",
+    "src/src/metrics",
+    "src/src/nl/netlist/decorators",
+    "src/src/nl/netlist/pnl",
+    "src/src/nl/netlist/visual",
+    "src/src/nl/netlist/serialization/capnp",
+    "src/src/nl/formats/lefdef",
+    "src/src/nl/formats/liberty",
+    "src/src/nl/formats/systemverilog/frontend",
+    "src/src/nl/formats/verilog/backend",
+    "src/src/nl/formats/verilog/frontend",
+    "src/src/nl/python/pyloader",
+    "src/src/optimization",
+    "src/thirdparty/cpptrace/include",
+    "src/thirdparty/naja-verilog/src",
+    "src/thirdparty/yosys-liberty/src",
+    "src/thirdparty/lefdef/src/def/def",
+]
 
 NAJA_HEADER_COPTS = [
     # Kepler and Naja's headers require C++20. The root module sets this via
     # .bazelrc (--cxxopt=-std=c++20), but that does not reach a downstream
     # consumer, so set it on the targets themselves.
     "-std=c++20",
-    "-iquoteexternal/+deps+naja/src/src/dnl",
-    "-iquoteexternal/+deps+naja/src/src/nl/netlist/core",
-    "-iquoteexternal/+deps+naja/src/src/nl/netlist/snl",
-    "-iquoteexternal/+deps+naja/src/src/core",
-    "-iquoteexternal/+deps+naja/src/src/bne",
-    "-iquoteexternal/+deps+naja/src/src/metrics",
-    "-iquoteexternal/+deps+naja/src/src/nl/netlist/decorators",
-    "-iquoteexternal/+deps+naja/src/src/nl/netlist/pnl",
-    "-iquoteexternal/+deps+naja/src/src/nl/netlist/visual",
-    "-iquoteexternal/+deps+naja/src/src/nl/netlist/serialization/capnp",
-    "-iquoteexternal/+deps+naja/src/src/nl/formats/lefdef",
-    "-iquoteexternal/+deps+naja/src/src/nl/formats/liberty",
-    "-iquoteexternal/+deps+naja/src/src/nl/formats/systemverilog/frontend",
-    "-iquoteexternal/+deps+naja/src/src/nl/formats/verilog/backend",
-    "-iquoteexternal/+deps+naja/src/src/nl/formats/verilog/frontend",
-    "-iquoteexternal/+deps+naja/src/src/nl/python/pyloader",
-    "-iquoteexternal/+deps+naja/src/src/optimization",
-    "-iquoteexternal/+deps+naja/src/thirdparty/cpptrace/include",
-    "-iquoteexternal/+deps+naja/src/thirdparty/naja-verilog/src",
-    "-iquoteexternal/+deps+naja/src/thirdparty/yosys-liberty/src",
-    "-iquoteexternal/+deps+naja/src/thirdparty/lefdef/src/def/def",
+] + [
+    "-iquote%s/%s" % (_NAJA_ROOT, d)
+    for d in _NAJA_QUOTE_INCLUDE_DIRS
 ]


### PR DESCRIPTION
NAJA_HEADER_COPTS hardcodes `-iquoteexternal/+deps+naja/...` — the canonical repo name when kepler-formal is the **root** module. In a downstream consumer (`bazel_dep` + `git_override`) the same repo materializes at `external/<consumer-visible-name>++deps+naja`, so the `-iquote` paths dangle, quoted includes fall through to the transitive system include paths, and headers resolve through two physical copies (naja source tree + cmake-installed include dir) that `#pragma once` cannot deduplicate:

```
src/src/nl/netlist/core/NLID.h:30:8: error: redefinition of 'NLID'
bazel-out/.../naja/include/NLID.h:30:8: note: previous definition is here
```

This PR derives the prefix from `Label("@naja//:BUILD").workspace_root` instead, so it follows the repo mapping in any context.

Verification:
- As root module: `bazel query --output=build //src/sec:kepler_sec` shows **byte-identical copts** to the previous hardcoded values (`-iquoteexternal/+deps+naja/...`), so nothing changes for this repo or its CI.
- As a consumer: we carry exactly this diff as a `git_override` patch; with it, `@kepler-formal//src/bin:kepler-formal` builds clean at 8af137d from a downstream module (previously: the NLID/NLIDComp redefinition errors above).