### PR TITLE
ci: consumer smoke test — build kepler-formal as a bzlmod dependency

### DIFF
--- a/.github/consumer-test/.bazelrc
+++ b/.github/consumer-test/.bazelrc
@@ -1,0 +1,10 @@
+common --enable_platform_specific_config
+
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
+
+# Same guards as the root .bazelrc: the hermetic toolchain must win
+# resolution, and host tools stay on C11 for the rules_foreign_cc
+# pkg-config bootstrap.
+common:linux --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --host_conlyopt=-std=c11

--- a/.github/consumer-test/MODULE.bazel
+++ b/.github/consumer-test/MODULE.bazel
@@ -1,0 +1,36 @@
+# Minimal downstream consumer of kepler-formal.
+#
+# Builds the checker exactly the way an external module does: bazel_dep +
+# override, no dev_dependencies. This catches breakage that is invisible
+# when this repo is the root module, e.g. paths spelled with root-module
+# canonical repo names (the repo mapping renames extension repos in a
+# consumer context).
+#
+# The root module's hermetic-llvm toolchain *registration* is a
+# dev_dependency and does not propagate; the toolchain repo itself does.
+# A consumer that wants the same hermetic build just registers it, as
+# here — which also keeps this smoke test independent of the CI runner's
+# host compiler. (Declaring exec/target tags again would duplicate the
+# generated toolchain rules.)
+module(name = "kepler-formal-consumer-test")
+
+bazel_dep(name = "kepler-formal")
+local_path_override(
+    module_name = "kepler-formal",
+    path = "../..",
+)
+
+bazel_dep(name = "llvm", version = "0.8.11")
+
+llvm_toolchains = use_extension("@llvm//extensions:toolchain.bzl", "toolchain")
+use_repo(llvm_toolchains, "llvm_toolchains")
+
+register_toolchains("@llvm_toolchains//:all")
+
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+
+register_toolchains(
+    "@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain",
+    "@rules_foreign_cc//toolchains:preinstalled_make_toolchain",
+    "@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain",
+)

--- a/.github/workflows/consumer.yml
+++ b/.github/workflows/consumer.yml
@@ -1,0 +1,45 @@
+# Build kepler-formal as a downstream bzlmod dependency. The root-module CI
+# cannot see consumer-only breakage: canonical repo names differ between the
+# two contexts, so e.g. a hardcoded external/+deps+naja path resolves as root
+# and dangles in a consumer. This job builds from a minimal consumer
+# workspace (.github/consumer-test) that depends on the checkout via
+# local_path_override.
+name: consumer-smoke
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-as-dependency:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Bazel outputs
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/bazel
+        key: bazel-consumer-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'bazel/deps.bzl', 'bazel/*.BUILD.bazel') }}
+        restore-keys: |
+          bazel-consumer-${{ runner.os }}-
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq \
+          build-essential pkg-config \
+          bison flex python3-dev
+
+    - name: Build kepler-formal as a dependency
+      working-directory: .github/consumer-test
+      run: bazelisk build @kepler-formal//src/bin:kepler-formal
+
+    - name: Dump rules_foreign_cc CMake log on failure
+      if: failure()
+      run: |
+        find .github/consumer-test/bazel-out -type f -name CMake.log -print -exec sed -n '1,260p' {} \; || true

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,7 +7,7 @@ Files: src/*
 Copyright: 2025 keplertech.io
 License: GPL-3.0-only
 
-Files: example/* .github/workflows/* .gitmodules README.md docs/*
+Files: example/* .github/workflows/* .github/consumer-test/* .gitmodules README.md docs/*
 Copyright: 2025 keplertech.io
 License: Apache-2.0
 


### PR DESCRIPTION
Root-module CI cannot see consumer-only breakage: bzlmod canonical repo names differ between the root and dependency contexts, so a path spelled with the root-module canonical name (`external/+deps+naja`) resolves in every job here and dangles for every downstream consumer. The recent naja update surfaced exactly that class (NLID redefinitions in consumer builds — fixed by #158), and nothing in CI could have caught it.

This adds `.github/consumer-test/` — a minimal module depending on the checkout via `local_path_override` — and a `consumer-smoke` workflow that builds `@kepler-formal//src/bin:kepler-formal` from inside it. The workspace doubles as documentation of how to consume kepler-formal as a dependency.

The consumer uses the **same hermetic-llvm toolchain as the root module**: the toolchain *registration* here is a dev_dependency and does not propagate, so the consumer registers `@llvm_toolchains//:all` itself (reusing the extension's existing tags — re-declaring `exec`/`target` tags from a second module generates duplicate toolchain rules, which may be worth a dedup fix in the `llvm` module). This keeps the smoke test independent of the CI runner's host compiler.

**Validated locally** (GCC 15 host, where a host-toolchain consumer build fails to even link capnproto): with #158's fix cherry-picked, the hermetic consumer build completes (`1016 processes … Build completed successfully`); without it, it fails with the NLID redefinitions.

**Expected status**: `build-as-dependency` is red on this PR until #158 merges — that redness is the test demonstrating it catches the gap. Suggest merging #158 first, then this.
