### PR TITLE
bazel: bump naja to najaeda 30f65197, matching the submodule pin

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -118,11 +118,11 @@ _FLEX_VERSION = "2.6.4"
 _CADICAL_COMMIT = "7b99c07f0bcab5824a5a3ce62c7066554017f641"
 _GLUCOSE_COMMIT = "7f887abba7cf13636a5ac2d28653668a20a91b25"
 _KISSAT_COMMIT = "8af8e56f174b778aef3aa45af9f739b2a5f492c2"
-_NAJA_COMMIT = "d2013782e7e8f5315be1161fc580bf6e78d6f4d8"
+_NAJA_COMMIT = "bfc5649c27ebbef9459da87da995aca950610487"
 _NAJA_VERILOG_COMMIT = "8a13b5986c765035548775808273d61defcaf738"
 _NAJA_IF_COMMIT = "8719bf93fdcd65534c75eb7a8a1f69393f74a75a"
 _CPPTRACE_COMMIT = "3db8da80111171c219ab5839905771386bee06b3"
-_SLANG_COMMIT = "aedd7bc0394e5621340be94ed58def33d74ac677"
+_SLANG_COMMIT = "512c327c209d3043aa98ecfd02d06a1b73fcd5fb"
 _GOOGLETEST_COMMIT = "52eb8108c5bdec04579160ae17225d66034bd723"
 
 def _deps_impl(_module_ctx):
@@ -184,8 +184,8 @@ def _deps_impl(_module_ctx):
 
     naja_repo(
         name = "naja",
-        naja_url = "https://github.com/nanocoh/naja/archive/{}.tar.gz".format(_NAJA_COMMIT),
-        naja_sha256 = "29b6701761e7b212afa29ad2ad12a7de10831cf49a26256ba6d333c4362d867a",
+        naja_url = "https://github.com/najaeda/naja/archive/{}.tar.gz".format(_NAJA_COMMIT),
+        naja_sha256 = "837a0f7919308f7484e33b59827306a9181cbb822b4b645e37998abef6bda59d",
         naja_strip_prefix = "naja-{}".format(_NAJA_COMMIT),
         naja_verilog_url = "https://github.com/najaeda/naja-verilog/archive/{}.tar.gz".format(_NAJA_VERILOG_COMMIT),
         naja_verilog_sha256 = "e5caf041d7c8867bb0805b8a182cc4330afc40d0dde74760f4ee42d10b70c9cb",
@@ -197,7 +197,7 @@ def _deps_impl(_module_ctx):
         cpptrace_sha256 = "77d689fd7956ff80351a079d83e86a03865dbbe2433b4559cc6cea50bed77390",
         cpptrace_strip_prefix = "cpptrace-{}".format(_CPPTRACE_COMMIT),
         slang_url = "https://github.com/najaeda/slang/archive/{}.tar.gz".format(_SLANG_COMMIT),
-        slang_sha256 = "8253cc083c075bbf21215a07ab4f73814a553f990530089c175fde5db37792e2",
+        slang_sha256 = "144054285e246801a579e1365fe50c4d0a04a188025c8cb2bbe2355f653f2cbd",
         slang_strip_prefix = "slang-{}".format(_SLANG_COMMIT),
         googletest_url = "https://github.com/google/googletest/archive/{}.tar.gz".format(_GOOGLETEST_COMMIT),
         googletest_sha256 = "745c55415660044610f7fcd3af7a6420d5de16a7dbb9ebfe2e131275676232be",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -118,7 +118,7 @@ _FLEX_VERSION = "2.6.4"
 _CADICAL_COMMIT = "7b99c07f0bcab5824a5a3ce62c7066554017f641"
 _GLUCOSE_COMMIT = "7f887abba7cf13636a5ac2d28653668a20a91b25"
 _KISSAT_COMMIT = "8af8e56f174b778aef3aa45af9f739b2a5f492c2"
-_NAJA_COMMIT = "bfc5649c27ebbef9459da87da995aca950610487"
+_NAJA_COMMIT = "30f65197f51c04dc3ec0ddd0143bb3b8f5e6db90"
 _NAJA_VERILOG_COMMIT = "8a13b5986c765035548775808273d61defcaf738"
 _NAJA_IF_COMMIT = "8719bf93fdcd65534c75eb7a8a1f69393f74a75a"
 _CPPTRACE_COMMIT = "3db8da80111171c219ab5839905771386bee06b3"
@@ -185,7 +185,7 @@ def _deps_impl(_module_ctx):
     naja_repo(
         name = "naja",
         naja_url = "https://github.com/najaeda/naja/archive/{}.tar.gz".format(_NAJA_COMMIT),
-        naja_sha256 = "837a0f7919308f7484e33b59827306a9181cbb822b4b645e37998abef6bda59d",
+        naja_sha256 = "0e394baf202b46efbd41324a4b3ffeaacc53fcf944a7a7f6c0480014325d57e1",
         naja_strip_prefix = "naja-{}".format(_NAJA_COMMIT),
         naja_verilog_url = "https://github.com/najaeda/naja-verilog/archive/{}.tar.gz".format(_NAJA_VERILOG_COMMIT),
         naja_verilog_sha256 = "e5caf041d7c8867bb0805b8a182cc4330afc40d0dde74760f4ee42d10b70c9cb",


### PR DESCRIPTION
The bazel build pins naja through `bazel/deps.bzl`'s `_NAJA_COMMIT`, independently of the `thirdparty/naja` git submodule — and the two have diverged. The submodule (at `30f65197`) contains najaeda/naja@af7695a1 (net-declaration assignment lowering), but `_NAJA_COMMIT` still pointed at nanocoh/naja@d2013782, which predates it. So #156 kept reproducing in bazel-built binaries even after the fix was "integrated" via 22fe386: cmake/submodule builds got the fix, bazel builds did not.

This bumps the bazel pin to **najaeda/naja@30f65197 — the exact commit the `thirdparty/naja` submodule records on `main`**, restoring deps.bzl's convention that bazel pins mirror the submodules:

- `_NAJA_COMMIT` → `30f65197f51c04dc3ec0ddd0143bb3b8f5e6db90`, URL moved from `nanocoh/naja` to `najaeda/naja`. Contains the #156 fix (af7695a1); the one nanocoh-only commit in `d2013782` ("table select generic tt") landed upstream as najaeda/naja#402 (63031add), so nothing is lost.
- `_SLANG_COMMIT` → `512c327c209d3043aa98ecfd02d06a1b73fcd5fb`, matching the slang submodule pin naja records at `30f65197`. naja's other submodule pins (naja-verilog, naja-if, cpptrace, googletest) already match deps.bzl.

### Why 30f65197 and not release 0.7.13 (bfc5649)

The first revision of this PR pinned `bfc5649` (0.7.13) and the bazel `build-and-test` job failed on `KeplerCliSubprocessTests.ExampleTestRunNajaIFWithScopeExtraction`:

```
Netlist loading failed: Incompatible SNL snapshot producer: snapshot was built by
naja version <missing>, git hash <missing>; reader is naja version 0.7.13, git hash unknown
```

The 0.7.13 release commit adds `checkManifestProducer()` to `SNLCapnP::load`, which rejects any naja-if snapshot whose recorded producer naja version **and git hash** don't exactly match the reader's. The checked-in `example/tinyrocket_naja*.if` fixtures were dumped by naja 0.2.4/0.6.5 (no producer stamp at all), and regenerating them can't help: naja stamps `NAJA_GIT_HASH` as `unknown` when built from a tarball (bazel) but as the real short hash when built from a git checkout (cmake submodule, pip wheels), so no checked-in fixture can satisfy both flows at ≥0.7.13. 30f65197 predates the check. Any future bump past bfc5649 first needs this resolved upstream (e.g. relax the exact-hash match or stamp the hash in tarball builds).

### Verification

Bazel-built `kepler-formal` at this commit, locally:

- Reproduced the CI failure at bfc5649, then re-ran at 30f65197: `bazel test //test/...` — all 5 targets pass, including `ExampleTestRunNajaIFWithScopeExtraction`.
- The #156 four-line reproducer (`wire x = a;`) elaborates with 100% checked-output coverage and SEC self-check proves at k = 0, matching the split-assign control; before the bump every output was skipped as no-driver.

Fixes #156.
