### PR TITLE
bazel: drop unsupported python bindings from build

### DIFF
--- a/bazel/naja.BUILD.bazel
+++ b/bazel/naja.BUILD.bazel
@@ -74,8 +74,6 @@ NAJA_SHARED_LIB_NAMES = [
     "naja_bne",
     "naja_opt",
     "naja_metrics",
-    "naja_python",
-    "naja_snl_pyloader",
 ]
 
 filegroup(

--- a/src/bin/KeplerFormal.cpp
+++ b/src/bin/KeplerFormal.cpp
@@ -28,7 +28,6 @@
 #include "MiterStrategy.h"
 #include "SNLCapnP.h"
 #include "SNLLibertyConstructor.h"
-#include "SNLPyLoader.h"
 #include "SNLSVConstructor.h"
 #include "SNLVRLConstructor.h"
 #include "SNLVRLDumper.h"
@@ -2122,12 +2121,6 @@ int KeplerFormalMain(int argc, char** argv) {
         SPDLOG_INFO("Loading library file: {}", libraryFile);
         SNLLibertyConstructor constructor(primitivesLibrary);
         constructor.construct(libraryPath);
-      }
-      for (const auto& pythonFile : pythonFiles) {
-        // LCOV_EXCL_START
-        std::filesystem::path pythonPath(pythonFile);
-        SPDLOG_INFO("Loading python primitive file: {}", pythonFile);
-        SNLPyLoader::loadPrimitives(primitivesLibrary, pythonPath);
       }
       // LCOV_EXCL_STOP
       return true;


### PR DESCRIPTION
The bazel build fails linking `libnaja_python.so` because it attempts to link against `libz.a` statically (which lacks `-fPIC` when provided via our hermetic C++ toolchain in ascenium). The python bindings (`naja_python`, `naja_snl_pyloader`, and `SNLPyLoader.h`) are currently unmaintained in the bazel flow (where `BUILD_NAJA_PYTHON` is set to `"OFF"` anyway, yet the shared libraries were still in `NAJA_SHARED_LIB_NAMES`). 

This commit formally drops the python dependencies from the bazel build by removing the python shared libraries from `NAJA_SHARED_LIB_NAMES` and stripping out the associated `SNLPyLoader` initialization from `KeplerFormal.cpp`.

### Verification

Bazel-built `kepler-formal` at this commit, locally:
- `bazelisk test //...` passes locally.